### PR TITLE
Travis: only run standard, not tape

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ node_js:
   - "0.11"
   - "0.10"
   - "iojs"
+
+script: npm run-script code-standard

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "compare-version": "^0.1.2"
   },
   "scripts": {
+    "code-standard": "standard",
     "pretest": "rimraf test/work",
     "test": "standard && tape test"
   },


### PR DESCRIPTION
If you run [`npm test` in Travis](https://travis-ci.org/electron-userland/electron-osx-sign/jobs/113849722#L200-L201), you get this message:

```
Test failed.
Command failed: /bin/sh -c which codesign
```

Oddly enough, it doesn't fail (even though it should). This PR just runs `standard` so contributors don't get confused by the Travis output.

Let me know if there's a more idiomatic Node way of doing this.

References #18.