### PR TITLE
Add keychain option

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,14 @@ See [default.mas.inherit.entitlements](https://github.com/electron-userland/elec
 `identity` - *String*
 
 Name of certificate to use when signing.
-Default to retrieve from `login.keychain`.
+Default to retrieve from `opts.keychain` (see below) or system default keychain.
 
 Signing platform `mas` will look for `3rd Party Mac Developer Application: * (*)`, and platform `darwin` will look for `Developer ID Application: * (*)` by default.
+
+`keychain` - *String*
+
+The keychain name.
+Default to system default keychain (`login.keychain`).
 
 `platform` - *String*
 
@@ -169,7 +174,7 @@ Needs file extension `.app`.
 `identity` - *String*
 
 Name of certificate to use when flattening.
-Default to retrieve from `login.keychain`.
+Default to retrieve from `opts.keychain`(see below) or system default keychain.
 
 Flattening platform `mas` will look for `3rd Party Mac Developer Installer: * (*)`, and platform `darwin` will look for `Developer ID Installer: * (*)` by default.
 
@@ -177,6 +182,11 @@ Flattening platform `mas` will look for `3rd Party Mac Developer Installer: * (*
 
 Path to install for the bundle.
 Default to `/Applications`.
+
+`keychain` - *String*
+
+The keychain name.
+Default to `login.keychain`.
 
 `platform` - *String*
 

--- a/bin/electron-osx-flat-usage.txt
+++ b/bin/electron-osx-flat-usage.txt
@@ -1,10 +1,10 @@
-
 Usage: electron-osx-flat <app> [--options...]
 
 Optional options
 
-identity                    Name of certificate to use when flattening. Default to retrieve from `login.keychain`.
+identity                    Name of certificate to use when flattening. Default to retrieve from keychain specified, see below.
 install                     Path to install for the bundle. Default `/Applications`.
+keychain                    The keychain name. Default to system default keychain (`login.keychain`).
 platform                    Build platform of Electron. Allowed values: darwin, mas. Default to auto detect from application package.
 pkg                         Path to the output package.
 verbose                     Verbose flag, to display logs.

--- a/bin/electron-osx-sign-usage.txt
+++ b/bin/electron-osx-sign-usage.txt
@@ -1,4 +1,3 @@
-
 Usage: electron-osx-sign <app> [additional-binaries...] [--options...]
 
 Optional options
@@ -6,6 +5,7 @@ Optional options
 binaries                    Path to additional binaries that will be signed along with built-ins of Electron, spaced.
 entitlements                Path to entitlements file for signing Mac App Store application.
 entitlements-inherit        Path to child entitlements file for signing frameworks and bundles of Mac App Store application.
-identity                    Name of certificate to use when signing. Default to retrieve from `login.keychain`.
+identity                    Name of certificate to use when signing. Default to retrieve from keychain specified, see below.
+keychain                    The keychain name. Default to system default keychain (`login.keychain`).
 platform                    Build platform of Electron. Allowed values: `darwin`, `mas`. Default to auto detect from application package.
 verbose                     Verbose flag, to display logs.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,21 @@
+interface BaseSignOptions {
+  app: string;
+  identity?: string;
+  platform?: string;
+  keychain?: string;
+}
+
+interface SignOptions extends BaseSignOptions {
+  binaries?: string[];
+  entitlements?: string;
+  'entitlements-inherit'?: string;
+}
+
+export function sign(opts: SignOptions, callback: (error: Error) => void): void
+
+interface FlatOptions extends BaseSignOptions {
+  pkg?: string;
+  install?: string;
+}
+
+export function flat(opts: FlatOptions, callback: (error: Error) => void): void


### PR DESCRIPTION
[electron-builder](https://github.com/electron-userland/electron-builder) now uses electron-osx-sign to sign app and MAS build.

Currently, I use my fork. Want to integrate my changes.

* use `execFile` instead of `exec` — no need to escape args.
* add  `keychain` option.
* remove code duplication — base args to `codesign` (so, the only place where add new `keychain` arg).

Also, I added TS definition file according to http://www.typescriptlang.org/docs/handbook/typings-for-npm-packages.html

Why  `keychain` is required? Because electron-builder is a complete solution and supports code signing on a CI servers.