### PR TITLE
Updated default entitlements

### DIFF
--- a/default.mas.entitlements
+++ b/default.mas.entitlements
@@ -4,5 +4,7 @@
   <dict>
     <key>com.apple.security.app-sandbox</key>
     <true/>
+    <key>com.apple.security.temporary-exception.sbpl</key>
+    <string>(allow mach-lookup (global-name-regex #"^org.chromium.Chromium.rohitfork.[0-9]+$"))</string>
   </dict>
 </plist>


### PR DESCRIPTION
As per http://electron.atom.io/docs/tutorial/mac-app-store-submission-guide/#sign-your-app
Its now necessary to have this second permission `temporary-exception`
The app will hang with a white screen without this
Related to https://github.com/electron/electron/issues/3871#issuecomment-211883141