### PR TITLE
Automating entitlement app group only if there is entitlements

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,8 @@ interface BaseSignOptions {
   identity?: string;
   platform?: string;
   keychain?: string;
+
+  version?: string;
 }
 
 interface SignOptions extends BaseSignOptions {
@@ -12,6 +14,7 @@ interface SignOptions extends BaseSignOptions {
 }
 
 export function sign(opts: SignOptions, callback: (error: Error) => void): void;
+export function signAsync(opts: SignOptions): Promise<any>;
 
 interface FlatOptions extends BaseSignOptions {
   pkg?: string;
@@ -19,3 +22,4 @@ interface FlatOptions extends BaseSignOptions {
 }
 
 export function flat(opts: FlatOptions, callback: (error: Error) => void): void;
+export function flatAsync(opts: FlatOptions): Promise<any>;

--- a/index.js
+++ b/index.js
@@ -499,20 +499,16 @@ function signAsync (opts) {
     })
     .then(function () {
       // Pre-sign operations
-      var promise = Promise.resolve()
-      if (opts.version ? compareVersion(opts.version, '1.1.1') >= 0 : true) {
+      if (opts.entitlements && (!opts.version || compareVersion(opts.version, '1.1.1') >= 0)) {
         // Enable Mac App Store sandboxing without using temporary-exception, introduced in Electron v1.1.1. Relates to electron#5601
         if (opts['pre-auto-entitlements'] === false) {
           debugwarn('Pre-sign operation disabled for entitlements automation.')
         } else {
           debuglog('Pre-sign operation enabled for entitlements automation with versions >= `1.1.1`; disable by setting `pre-auto-entitlements` to `false`.')
-          promise = promise.then(function () {
-            debuglog('Automating entitlement app group...')
-            return preAutoEntitlementAppGroupAsync(opts)
-          })
+          debuglog('Automating entitlement app group...')
+          return preAutoEntitlementAppGroupAsync(opts)
         }
       }
-      return promise
     })
     .then(function () {
       debuglog('Signing application...')


### PR DESCRIPTION
Otherwise if platform `darwin` no entitlements by default and sign failed because `preAutoEntitlementAppGroupAsync` does `readFileAsync(opts.entitlements, 'utf8')`