### PR TITLE
Add requirements option

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,11 @@ Flag to enable automation of `com.apple.security.application-groups` in entitlem
 Allowed values: `true`, `false`.
 Default to `true`.
 
+`requirements` - *String*
+
+Specify the criteria that you recommend to be used to evaluate the code signature.
+See more info from https://developer.apple.com/library/mac/documentation/Security/Conceptual/CodeSigningGuide/RequirementLang/RequirementLang.html
+
 `version` - *String*
 
 Build version of Electron.

--- a/bin/electron-osx-sign-usage.txt
+++ b/bin/electron-osx-sign-usage.txt
@@ -12,3 +12,4 @@ ignore                    Regex that signals ignoring a file before signing. Def
 no-pre-auto-entitlements  Flag to disable automation of `com.apple.security.application-groups` in entitlements file and update `Info.plist` with `ElectronTeamID`.
 platform                  Build platform of Electron. Allowed values: `darwin`, `mas`. Default to auto detect from application package.
 version                   Build version of Electron. Values may be: `1.2.0`.
+requirements              Specify the criteria that you recommend to be used to evaluate the code signature. Default to undefined.

--- a/index.js
+++ b/index.js
@@ -378,6 +378,9 @@ function signApplicationAsync (opts) {
       if (opts.keychain) {
         args.push('--keychain', opts.keychain)
       }
+      if (opts.requirements) {
+        args.push('--requirements', opts.requirements)
+      }
 
       var promise
       if (opts.entitlements) {


### PR DESCRIPTION
Add possibility to give the criteria that user recommends to be used to evaluate the code signature.