### PR TITLE
Backport requirements option

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,11 @@ Build platform of Electron.
 Allowed values: `darwin`, `mas`.
 Default to auto detect from presence of `Squirrel.framework` within the application package.
 
+`requirements` - *String*
+
+Specify the criteria that you recommend to be used to evaluate the code signature.
+See more info from https://developer.apple.com/library/mac/documentation/Security/Conceptual/CodeSigningGuide/RequirementLang/RequirementLang.html
+
 ###### callback
 
 `err` - *Error*

--- a/bin/electron-osx-sign-usage.txt
+++ b/bin/electron-osx-sign-usage.txt
@@ -9,3 +9,4 @@ identity                    Name of certificate to use when signing. Default to 
 keychain                    The keychain name. Default to system default keychain (`login.keychain`).
 ignore                      Regex that signals ignoring a file before signing. Default to undefined.
 platform                    Build platform of Electron. Allowed values: `darwin`, `mas`. Default to auto detect from application package.
+requirements                Specify the criteria that you recommend to be used to evaluate the code signature. Default to undefined.

--- a/index.js
+++ b/index.js
@@ -164,6 +164,9 @@ function signApplication (opts, callback) {
   if (opts.keychain) {
     args.push('--keychain', opts.keychain)
   }
+  if (opts.requirements) {
+    args.push('--requirements', opts.requirements)
+  }
 
   if (opts.entitlements) {
     // Sign with entitlements


### PR DESCRIPTION
:wave:

I wasn’t sure what the current status of the 0.4 rewrite was, but we need the `requirements` option so I figured I’d backport this in case there was any interest in creating a 0.3.2.

Backports https://github.com/electron-userland/electron-osx-sign/pull/68 on top of 0.3.1