### PR TITLE
Added 'scripts' as an optional paramter

### DIFF
--- a/bin/electron-osx-flat-usage.txt
+++ b/bin/electron-osx-flat-usage.txt
@@ -8,3 +8,4 @@ install   Path to install for the bundle. Default `/Applications`.
 keychain  The keychain name. Default to system default keychain.
 platform  Build platform of Electron. Allowed values: darwin, mas. Default to auto detect from application package.
 pkg       Path to the output package.
+scripts   Path to a directory containing pre and/or post install scripts.

--- a/index.js
+++ b/index.js
@@ -619,7 +619,7 @@ function flatAsync (opts) {
       debuglog('> package-output ' + opts.pkg)
       debuglog('> install-path   ' + opts.install)
       debuglog('> identity       ' + opts.identity)
-      debuglog('> scripts        ', opts.scripts)
+      debuglog('> scripts        ' + opts.scripts)
       return flatApplicationAsync(opts)
     })
     .then(function () {

--- a/index.js
+++ b/index.js
@@ -98,6 +98,9 @@ function flatApplicationAsync (opts) {
   if (opts.keychain) {
     args.unshift('--keychain', opts.keychain)
   }
+  if (opts.scripts) {
+    args.unshift('--scripts', opts.scripts)
+  }
 
   debuglog('Flattening... ' + opts.app)
   return execFileAsync('productbuild', args)
@@ -616,6 +619,7 @@ function flatAsync (opts) {
       debuglog('> package-output ' + opts.pkg)
       debuglog('> install-path   ' + opts.install)
       debuglog('> identity       ' + opts.identity)
+      debuglog('> scripts        ', opts.scripts)
       return flatApplicationAsync(opts)
     })
     .then(function () {


### PR DESCRIPTION
Added an option to accept 'scripts' as a parameter. Scripts is used by productBuild to accept pre and/or post install scripts.