### PR TITLE
Allow platform/type specific provisioning profiles

### DIFF
--- a/sign.js
+++ b/sign.js
@@ -339,6 +339,13 @@ var signAsync = module.exports.signAsync = function (opts) {
       })
     })
     .then(function () {
+      debuglog('Signing application...', '\n',
+        '> Application:', opts.app, '\n',
+        '> Platform:', opts.platform, '\n',
+        '> Entitlements:', opts.entitlements, '\n',
+        '> Child entitlements:', opts['entitlements-inherit'], '\n',
+        '> Additional binaries:', opts.binaries, '\n',
+        '> Identity:', opts.identity)
       return signApplicationAsync(opts)
     })
     .then(function () {


### PR DESCRIPTION
Development:

- Mac App Development
Create a provisioning profile to install development apps on test
devices.

Distribution:

- Developer ID
Create a Developer ID provisioning profile to use Apple services with
your Developer ID signed applications.

- Mac App Store
Create a distribution provisioning profile to submit your app to the
Mac App Store.

Refer to: https://developer.apple.com/account/mac/profile/create