### PR TITLE
Fix #117: codesign --verify fails with "no such file or directory"

### DIFF
--- a/sign.js
+++ b/sign.js
@@ -85,11 +85,11 @@ function verifySignApplicationAsync (opts) {
   debuglog('Verifying application bundle with codesign...')
   var promise = execFileAsync('codesign', [
     '--verify',
-    '--deep',
-    compareVersion(osRelease, '15.0.0') >= 0 ? '--strict' : '', // Only pass strict flag in El Capitan and later
-    '--verbose=2',
-    opts.app
-  ])
+    '--deep']
+    .concat(compareVersion(osRelease, '15.0.0') >= 0 ? ['--strict'] : [], // Only pass strict flag in El Capitan and later
+    ['--verbose=2',
+    opts.app])
+  )
 
   // Additionally test Gatekeeper acceptance for darwin platform
   if (opts.platform === 'darwin' && opts['gatekeeper-assess'] !== false) {

--- a/sign.js
+++ b/sign.js
@@ -88,7 +88,7 @@ function verifySignApplicationAsync (opts) {
     '--deep']
     .concat(compareVersion(osRelease, '15.0.0') >= 0 ? ['--strict'] : [], // Only pass strict flag in El Capitan and later
     ['--verbose=2',
-    opts.app])
+      opts.app])
   )
 
   // Additionally test Gatekeeper acceptance for darwin platform


### PR DESCRIPTION
Avoid the empty string argument in the `code sign --verify` if Darwin version is lower than 15.0 as explained in #117 