### PR TITLE
Add timestamp option

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,11 @@ Specify the criteria that you recommend to be used to evaluate the code signatur
 See more info from https://developer.apple.com/library/mac/documentation/Security/Conceptual/CodeSigningGuide/RequirementLang/RequirementLang.html
 Default to `undefined`.
 
+`timestamp` - *String*
+
+Specify the URL of the timestamp authority server, default to server provided by Apple. Please note that this default server may not support signatures not furnished by Apple.
+Disable the timestamp service with `none`.
+
 `type` - *String*
 
 Specify whether to sign app for development or for distribution.

--- a/bin/electron-osx-sign-usage.txt
+++ b/bin/electron-osx-sign-usage.txt
@@ -56,6 +56,10 @@ DESCRIPTION
   --requirements=requirements
     Specify the criteria that you recommend to be used to evaluate the code signature.
 
+  --timestamp=timestamp
+    Specify the URL of the timestamp authority server, default to server provided by Apple.
+    Disable the timestamp service with ``none''.
+
   --type=type
     Specify whether to sign app for development or for distribution.
     Allowed values: ``development'', ``distribution''.

--- a/sign.js
+++ b/sign.js
@@ -143,6 +143,9 @@ function signApplicationAsync (opts) {
       if (opts.requirements) {
         args.push('--requirements', opts.requirements)
       }
+      if (opts['timestamp-none']) {
+        args.push('--timestamp=none')
+      }
 
       var promise
       if (opts.entitlements) {

--- a/sign.js
+++ b/sign.js
@@ -143,8 +143,8 @@ function signApplicationAsync (opts) {
       if (opts.requirements) {
         args.push('--requirements', opts.requirements)
       }
-      if (opts['timestamp-none']) {
-        args.push('--timestamp=none')
+      if (opts.timestamp) {
+        args.push('--timestamp', opts.timestamp)
       }
 
       var promise


### PR DESCRIPTION
For issue #132 ,
Add `--timestamp-none` option to use `--timestamp=none` when running `codesign`