### PR TITLE
Add use-cert-id option

### DIFF
--- a/util-identities.js
+++ b/util-identities.js
@@ -32,12 +32,12 @@ module.exports.findIdentitiesAsync = function (opts, identity) {
     .then(function (result) {
       return result.split('\n').map(function (line) {
         if (line.indexOf(identity) >= 0) {
-          var identityFound = opts['use-cert-id']
-            ? line.substring(line.indexOf(')') + 2, line.indexOf('"') - 1)
-            : line.substring(line.indexOf('"') + 1, line.lastIndexOf('"'))
+          var identityFound = line.substring(line.indexOf('"') + 1, line.lastIndexOf('"'))
+          var identityHashFound = line.substring(line.indexOf(')') + 2, line.indexOf('"') - 1)
           debuglog('Identity:', '\n',
-            '> Name:', identityFound)
-          return identityFound
+            '> Name:', identityFound, '\n',
+            '> Hash:', identityHashFound)
+          return identityHashFound
         }
       })
     })

--- a/util-identities.js
+++ b/util-identities.js
@@ -32,7 +32,9 @@ module.exports.findIdentitiesAsync = function (opts, identity) {
     .then(function (result) {
       return result.split('\n').map(function (line) {
         if (line.indexOf(identity) >= 0) {
-          var identityFound = line.substring(line.indexOf('"') + 1, line.lastIndexOf('"'))
+          var identityFound = opts['use-cert-id']
+            ? line.substring(line.indexOf(')') + 2, line.indexOf('"') - 1)
+            : line.substring(line.indexOf('"') + 1, line.lastIndexOf('"'))
           debuglog('Identity:', '\n',
             '> Name:', identityFound)
           return identityFound


### PR DESCRIPTION
For issue #132,
Add `--use-cert-id` option to use the cert id instead of cert name 