### PR TITLE
Remove tempfile dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,25 +18,24 @@
   },
   "homepage": "https://github.com/electron-userland/electron-osx-sign",
   "dependencies": {
-    "bluebird": "^3.4.7",
+    "bluebird": "^3.5.0",
     "compare-version": "^0.1.2",
-    "debug": "^2.6.1",
+    "debug": "^2.6.8",
     "isbinaryfile": "^3.0.2",
     "minimist": "^1.2.0",
-    "plist": "^2.0.1",
-    "tempfile": "^1.1.1"
+    "plist": "^2.1.0"
   },
   "devDependencies": {
-    "electron-download": "^4.0.0",
-    "eslint": "^3.16.1",
+    "electron-download": "^4.1.0",
+    "eslint": "^4.2.0",
     "eslint-config-eslint": "^4.0.0",
-    "extract-zip": "^1.6.0",
+    "extract-zip": "^1.6.5",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.6.1",
     "run-series": "^1.1.4",
     "run-waterfall": "^1.1.3",
-    "standard": "^8.6.0",
-    "tape": "^4.6.3"
+    "standard": "^10.0.2",
+    "tape": "^4.7.0"
   },
   "scripts": {
     "code-standard": "standard",
@@ -49,6 +48,6 @@
     ]
   },
   "engines": {
-    "node": ">=0.4.0"
+    "node": ">=4.0.0"
   }
 }

--- a/util-entitlements.js
+++ b/util-entitlements.js
@@ -7,13 +7,15 @@
 const path = require('path')
 
 const plist = require('plist')
-const tempfile = require('tempfile')
+const os = require('os')
 
 const util = require('./util')
 const debuglog = util.debuglog
 const getAppContentsPath = util.getAppContentsPath
 const readFileAsync = util.readFileAsync
 const writeFileAsync = util.writeFileAsync
+
+let tmpFileCounter = 0
 
 /**
  * This function returns a promise completing the entitlements automation: The process includes checking in `Info.plist` for `ElectronTeamID` or setting parsed value from identity, and checking in entitlements file for `com.apple.security.application-groups` or inserting new into array. A temporary entitlements file may be created to replace the input for any changes introduced.
@@ -88,7 +90,7 @@ module.exports.preAutoEntitlements = function (opts) {
             debuglog('`com.apple.security.application-groups` found in entitlements file: ' + appIdentifier)
           }
           // Create temporary entitlements file
-          var entitlementsPath = tempfile('.plist')
+          const entitlementsPath = path.join(os.tmpdir(), `tmp-entitlements-${process.pid.toString(16)}-${(tmpFileCounter++).toString(16)}.plist`)
           opts.entitlements = entitlementsPath
           return writeFileAsync(entitlementsPath, plist.build(entitlements), 'utf8')
             .then(function () {

--- a/util-entitlements.js
+++ b/util-entitlements.js
@@ -4,10 +4,10 @@
 
 'use strict'
 
+const os = require('os')
 const path = require('path')
 
 const plist = require('plist')
-const os = require('os')
 
 const util = require('./util')
 const debuglog = util.debuglog


### PR DESCRIPTION
Reduce node_modules size — use the same approach to generate temp file as electron-builder/electron-download