### PR TITLE
Setting entitlements fails when app group value is a string

### DIFF
--- a/util-entitlements.js
+++ b/util-entitlements.js
@@ -83,7 +83,7 @@ module.exports.preAutoEntitlements = function (opts) {
             entitlements['com.apple.security.application-groups'] = []
           }
           // Insert app group if not exists
-          if (entitlements['com.apple.security.application-groups'].indexOf(appIdentifier) === -1) {
+          if (Array.isArray(entitlements['com.apple.security.application-groups']) && entitlements['com.apple.security.application-groups'].indexOf(appIdentifier) === -1) {
             debuglog('`com.apple.security.application-groups` not found in entitlements file, new inserted: ' + appIdentifier)
             entitlements['com.apple.security.application-groups'].push(appIdentifier)
           } else {


### PR DESCRIPTION
-A false positive occurs when a string is set as the value for com.apple.security.application-groups in entitlements.
-Originally the check looked for the absence of app identifier in an array, which returned true even if the input is a string.
-This fixes that by ensuring the value is an array before searching for app identifier.