### PR TITLE
Fix timestamp option

### DIFF
--- a/sign.js
+++ b/sign.js
@@ -153,7 +153,7 @@ function signApplicationAsync (opts) {
         args.push('--requirements', opts.requirements)
       }
       if (opts.timestamp) {
-        args.push('--timestamp', opts.timestamp)
+        args.push('--timestamp=' + opts.timestamp)
       }
 
       var promise


### PR DESCRIPTION
`codesign`'s `--timestamp` takes an optional value.

Fixes #163