### PR TITLE
Fix requirements option, like timestamp.

### DIFF
--- a/sign.js
+++ b/sign.js
@@ -150,7 +150,7 @@ function signApplicationAsync (opts) {
         args.push('--keychain', opts.keychain)
       }
       if (opts.requirements) {
-        args.push('--requirements', opts.requirements)
+        args.push('-r=' + opts.requirements)
       }
       if (opts.timestamp) {
         args.push('--timestamp=' + opts.timestamp)


### PR DESCRIPTION
This is a workaround for what appears to be a problem in codesign's argument parsing. Here are all the forms that don't work (look at the variation in the 'requirements' argument specifically):

```
$ codesign -s "Slack Desktop Test-Only" --requirements="designated => identifier foo" somefile
designated => identifier foo: No such file or directory
invalid requirement specification

$ codesign -d -r- somefile
somefile: code object is not signed at all

$ codesign -s "Slack Desktop Test-Only" -r "designated => identifier foo" somefile
designated => identifier foo: No such file or directory
invalid requirement specification

$ codesign -s "Slack Desktop Test-Only" --requirements="designated => identifier foo" somefile
designated => identifier foo: No such file or directory
invalid requirement specification
```

And here's the one that does:

```
$ codesign -s "Slack Desktop Test-Only" -r="designated => identifier foo" somefile

$ codesign -d -r- somefile
Executable=/Users/finnre/slack/slack-desktop/spec/e2e/somefile
designated => identifier foo
```

This PR changes how electron-osx-sign passes the requirements argument through to codesign, to accomodate this.