### PR TITLE
Fix ReDoS vulnerability (CWE-400)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "debug": "^2.6.8",
     "isbinaryfile": "^3.0.2",
     "minimist": "^1.2.0",
-    "plist": "^2.1.0"
+    "plist": "^3.0.1"
   },
   "devDependencies": {
     "electron-download": "^4.1.0",


### PR DESCRIPTION
This PR upgrades `plist` to v3.0.1. According to [Snyk](https://snyk.io/vuln/npm:plist:20180219), versions prior to to v3.0.1 were vulnerable to a [Regex Denial of Service attack](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS). While this might not necessarily affect `electron-osx-sign`, it could be causing dependency audit pipelines to fail (ours included) so it should be fixed imho. While this is a major version bump (from v2.1.0 to v3.0.1), according to the discussion on https://github.com/TooTallNate/plist.js/issues/89 this seems to be considered breaking because it caused them to drop support for Node v4. 